### PR TITLE
create logout view

### DIFF
--- a/app/assets/stylesheets/config/gray-background.scss
+++ b/app/assets/stylesheets/config/gray-background.scss
@@ -1,0 +1,4 @@
+.gray-background{
+  width: 100%;
+  background-color: #F5F5F5;
+}

--- a/app/assets/stylesheets/config/gray-background.scss
+++ b/app/assets/stylesheets/config/gray-background.scss
@@ -1,4 +1,0 @@
-.gray-background{
-  width: 100%;
-  background-color: #F5F5F5;
-}

--- a/app/assets/stylesheets/config/wrap.scss
+++ b/app/assets/stylesheets/config/wrap.scss
@@ -1,0 +1,14 @@
+.gray-background{
+  width: 100%;
+  background-color: #F5F5F5;
+}
+
+.user-page{
+  width: 1020px;
+  margin: 0 auto;
+  &__content{
+    float: right;
+    width: 700px;
+    margin-top: 40px;
+  }
+}

--- a/app/assets/stylesheets/modules/logout.scss
+++ b/app/assets/stylesheets/modules/logout.scss
@@ -1,0 +1,13 @@
+.logout{
+  background-color: white;
+  height: 180px;
+  position: relative;
+  &__button{
+    padding: 15px 120px;
+    background-color: #D84638;
+    color: white;
+    position: absolute;
+    top: 60px;
+    left: 220px;
+  }
+}

--- a/app/assets/stylesheets/modules/side-bar.scss
+++ b/app/assets/stylesheets/modules/side-bar.scss
@@ -1,7 +1,7 @@
 .side-bar{
-  padding: 20px;
+  padding: 20px 0;
   &__box{
-    margin: 20px;
+    margin: 20px 0;
   }
   &__list{
     width: 240px;

--- a/app/assets/stylesheets/modules/side-bar.scss
+++ b/app/assets/stylesheets/modules/side-bar.scss
@@ -1,0 +1,27 @@
+.side-bar{
+  padding: 20px;
+  &__box{
+    margin: 20px;
+  }
+  &__list{
+    width: 240px;
+    height: 50px;
+    background-color: white;
+    line-height: 50px;
+    border:  0.5px solid #EEEEEE;
+    padding: 0 20px;
+  }
+  &__name{
+    display: inline-block;
+    font-size: 14px;
+  }
+  &__greater-than{
+    display: inline-block;
+    float: right;
+    margin-top: 15px;
+    color: #CCCCCC;
+  }
+  &__title{
+    font-weight: bold;
+  }
+}

--- a/app/views/product/_side-bar.html.haml
+++ b/app/views/product/_side-bar.html.haml
@@ -1,0 +1,76 @@
+.side-bar
+  .side-bar__box
+    .side-bar__list
+      .side-bar__name マイページ
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name お知らせ
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name やることリスト
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name いいね！一覧
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name 出品する
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name 出品した商品-出品中
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name 出品した商品-取引中
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name 出品した商品-売却済み
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name 購入した商品-取引中
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name 購入した商品-過去の取引
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name ニュース一覧
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name 評価一覧
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name ガイド
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name お問い合わせ
+      .side-bar__greater-than.fas.fa-greater-than
+  .side-bar__box
+    .side-bar__title 売上・ポイント
+    .side-bar__list
+      .side-bar__name 売上・振込申請
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name ポイント
+      .side-bar__greater-than.fas.fa-greater-than
+  .side-bar__box
+    .side-bar__title 設定
+    .side-bar__list
+      .side-bar__name プロフィール
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name 住所変更
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name 支払い方法
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name メール/パスワード
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name 本人情報
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name 電話番号の確認
+      .side-bar__greater-than.fas.fa-greater-than
+    .side-bar__list
+      .side-bar__name ログアウト
+      .side-bar__greater-than.fas.fa-greater-than
+

--- a/app/views/product/_top-button.html.haml
+++ b/app/views/product/_top-button.html.haml
@@ -1,0 +1,4 @@
+= link_to root_path, class: 'top-button' do
+  .top-button__icon
+    .top-button__name 出品
+    .top-button__camera.fas.fa-camera

--- a/app/views/product/_top-footer.html.haml
+++ b/app/views/product/_top-footer.html.haml
@@ -1,3 +1,6 @@
+.top__app-introduction
+  = image_tag "app-introduction.png", class: :"top__app-introduction__image"
+
 .top-footer__wrap
   .top-footer
     .top-footer__about-mercari

--- a/app/views/product/index.html.haml
+++ b/app/views/product/index.html.haml
@@ -4,7 +4,7 @@
   .top-banner
     = image_tag "banner-featured-hobby.jpg", class: :"top-banner__image"
 
-  .top-main__wrap
+  .gray-background
     .top-main
       .top-main__title ピックアップカテゴリー
       .top-main__category

--- a/app/views/product/index.html.haml
+++ b/app/views/product/index.html.haml
@@ -16,12 +16,5 @@
           = render "product"
       .top-main__all-product-link すべての商品を見る
 
-  .top__app-introduction
-    = image_tag "app-introduction.png", class: :"top__app-introduction__image"
-
   = render "top-footer"
-
-  = link_to root_path, class: 'top-button' do
-    .top-button__icon
-      .top-button__name 出品
-      .top-button__camera.fas.fa-camera
+  = render "top-button"

--- a/app/views/product/logout.html.haml
+++ b/app/views/product/logout.html.haml
@@ -1,2 +1,11 @@
 = render "top-header"
 
+.gray-background
+  .user-page
+    .user-page__content
+      .logout
+        = link_to "ログアウト",root_path, class: 'logout__button'
+
+    = render "side-bar"
+= render "top-footer"
+= render "top-button"

--- a/app/views/product/logout.html.haml
+++ b/app/views/product/logout.html.haml
@@ -1,0 +1,2 @@
+= render "top-header"
+


### PR DESCRIPTION
# WHAT
ログアウトのビューを実装
（サイドバーのテンプレート含む）

トップページのビューを流用する為、下記を編集
・トップページの出品ボタンを部分テンプレート化して利用
・トップページのアプリ紹介のバナーの記述場所を、フッターの部分テンプレートに変更して利用
・グレーの背景をgray-backgroundクラスで共有できる様にscssファイル作成

コントローラ未作成の為、view/productに仮で配置。
サーバーサイド実装時に、適切なフォルダに移動予定。

# WHY
必須機能のため

![d3ca3ee258ac8d8a8f4b2bb516f0db76](https://user-images.githubusercontent.com/46085212/51926753-5639b580-2435-11e9-9120-880545c8b424.gif)