### PR TITLE
fix category

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,6 @@
 class ProductsController < ApplicationController
    before_action :set_product, only: [:show, :buy, :pay, :edit, :update, :destroy, :preview, :previewChange]
+   before_action :set_category, only: [:show, :preview,]
 
   def new
     @product = Product.new
@@ -128,6 +129,15 @@ class ProductsController < ApplicationController
 
   def set_product
     @product = Product.find(params[:id])
+  end
+
+  def set_category
+    @category_large = Category.find_by(id: @product.category_large)
+    @category_middle = Category.find_by(id: @product.category_middle)
+    @category_small = Category.find_by(id: @product.category_small)
+    @category_large ||= Category.new
+    @category_middle ||= Category.new
+    @category_small ||= Category.new
   end
 
   def category_large_params

--- a/app/views/products/preview.html.haml
+++ b/app/views/products/preview.html.haml
@@ -44,13 +44,13 @@
               .table__box__item
                 .table__box__item__detail
                   %h3.table__box__item__detail--text
-                    =@product.category_large
+                    =@category_large.name
                   .table__box__item__detail--text
                     %i.fas.fa-angle-right
-                      =@product.category_middle
+                      =@category_middle.name
                   .table__box__item__detail--text
                     %i.fas.fa-angle-right
-                      =@product.category_small
+                      =@category_small.name
             .table__box
               .table__box__title
                 %h3.table__box__title--text ブランド

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -50,13 +50,13 @@
               .table__box__item
                 .table__box__item__detail
                   %h3.table__box__item__detail--text
-                    =@product.category_large
+                    =@category_large.name
                   .table__box__item__detail--text
                     %i.fas.fa-angle-right
-                      =@product.category_middle
+                      =@category_middle.name
                   .table__box__item__detail--text
                     %i.fas.fa-angle-right
-                      =@product.category_small
+                      =@category_small.name
             .table__box
               .table__box__title
                 %h3.table__box__title--text ブランド


### PR DESCRIPTION
カテゴリ機能実装に伴いenumを削除したことで、
商品詳細画面とプレビュー画面でカテゴリ名が数字で表示されてしまうバグを修正